### PR TITLE
chore(deps): upgrade TypeScript 5.9.3 to 6.0.2

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@radix-icons/vue": "^1.0.0",
         "@tailwindcss/vite": "^4.2.2",
@@ -52,7 +52,7 @@
         "playwright": "^1.59.1",
         "prettier": "^3.8.1",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.2",
         "vite": "^7.3.2",
         "vite-plugin-compression2": "^2.5.3",
         "vitest": "^4.1.2",
@@ -6766,9 +6766,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,7 @@
     "playwright": "^1.59.1",
     "prettier": "^3.8.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "vite": "^7.3.2",
     "vite-plugin-compression2": "^2.5.3",
     "vitest": "^4.1.2",

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -8,7 +8,6 @@
     "checkJs": false,
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,7 +5,6 @@
     { "path": "./tsconfig.node.json" }
   ],
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary

- Upgrades TypeScript from 5.9.3 to 6.0.2 (major version)
- Removes deprecated `baseUrl` compiler option from `tsconfig.json` and `tsconfig.app.json` per [TS6 migration guide](https://aka.ms/ts6) — `paths` works without it when using relative paths (`./src/*`)

### Why this was excluded from #156
The original Dependabot PR (#145) had CI failures due to the vite security vulnerabilities (npm audit) that existed at the time. Those are now resolved.

Closes #145

## Test plan
- [x] `vue-tsc --noEmit` passes (no type errors)
- [x] ESLint passes
- [x] Prettier format check passes
- [x] Frontend build succeeds (vite-ssg)
- [x] All 116 frontend tests pass (13 files)
- [ ] CI pipeline passes